### PR TITLE
[Claude Code] Opus デコーダーの実装を追加する

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ nanobind_add_module(
   src/libdatachannel_ext.cpp
   src/openh264_video_encoder.cpp
   src/opus_audio_encoder.cpp
+  src/opus_audio_decoder.cpp
   src/video_codec.cpp
   src/videotoolbox_video_encoder.cpp
 )

--- a/src/audio_codec.h
+++ b/src/audio_codec.h
@@ -59,4 +59,21 @@ class AudioEncoder {
       std::function<void(const EncodedAudio&)> on_encode) = 0;
 };
 
+class AudioDecoder {
+ public:
+  struct Settings {
+    AudioCodecType codec_type;
+    int sample_rate;
+    int channels;
+  };
+
+  virtual ~AudioDecoder() = default;
+
+  virtual bool Init(const Settings& settings) = 0;
+  virtual void Release() = 0;
+  virtual void Decode(const EncodedAudio& encoded) = 0;
+  virtual void SetOnDecode(
+      std::function<void(const AudioFrame&)> on_decode) = 0;
+};
+
 #endif

--- a/src/bind_codec.cpp
+++ b/src/bind_codec.cpp
@@ -17,6 +17,7 @@
 #include "audio_codec.h"
 #include "openh264_video_encoder.h"
 #include "opus_audio_encoder.h"
+#include "opus_audio_decoder.h"
 #include "video_codec.h"
 #include "videotoolbox_video_encoder.h"
 
@@ -144,6 +145,22 @@ void bind_audio_codec(nb::module_& m) {
       .def_rw("frame_duration_ms", &AudioEncoder::Settings::frame_duration_ms);
 
   m.def("create_opus_audio_encoder", &CreateOpusAudioEncoder);
+
+  // AudioDecoder
+  nb::class_<AudioDecoder> decoder(m, "AudioDecoder");
+  decoder.def("init", &AudioDecoder::Init)
+      .def("release", &AudioDecoder::Release)
+      .def("decode", &AudioDecoder::Decode)
+      .def("set_on_decode", &AudioDecoder::SetOnDecode);
+
+  // AudioDecoder::Settings
+  nb::class_<AudioDecoder::Settings>(decoder, "Settings")
+      .def(nb::init<>())
+      .def_rw("codec_type", &AudioDecoder::Settings::codec_type)
+      .def_rw("sample_rate", &AudioDecoder::Settings::sample_rate)
+      .def_rw("channels", &AudioDecoder::Settings::channels);
+
+  m.def("create_opus_audio_decoder", &CreateOpusAudioDecoder);
 }
 
 }  // namespace

--- a/src/opus_audio_decoder.cpp
+++ b/src/opus_audio_decoder.cpp
@@ -1,0 +1,91 @@
+#include "opus_audio_decoder.h"
+
+#include <chrono>
+#include <functional>
+#include <vector>
+
+// opus
+#include <opus.h>
+
+// plog
+#include <plog/Log.h>
+
+class OpusAudioDecoder : public AudioDecoder {
+ public:
+  OpusAudioDecoder() {}
+  ~OpusAudioDecoder() override { Release(); }
+
+  bool Init(const Settings& settings) override {
+    Release();
+    settings_ = settings;
+
+    if (settings_.channels != 1 && settings_.channels != 2) {
+      PLOG_ERROR << "Invalid channels: " << settings_.channels;
+      return false;
+    }
+
+    int error = 0;
+    decoder_ = opus_decoder_create(settings_.sample_rate, settings_.channels, &error);
+    if (error != OPUS_OK) {
+      PLOG_ERROR << "Failed to create opus decoder";
+      return false;
+    }
+
+    // デコード用のバッファを初期化
+    // Opus では最大 5760 サンプル (120ms @ 48kHz) まで
+    pcm_buf_.resize(5760 * settings_.channels);
+    return true;
+  }
+
+  void Release() override {
+    if (decoder_ != nullptr) {
+      opus_decoder_destroy(decoder_);
+      decoder_ = nullptr;
+    }
+  }
+
+  void Decode(const EncodedAudio& encoded) override {
+    if (decoder_ == nullptr) {
+      PLOG_ERROR << "Decoder not initialized";
+      return;
+    }
+
+    int samples = opus_decode_float(decoder_, encoded.data.data(), encoded.data.shape(0),
+                                    pcm_buf_.data(), pcm_buf_.size() / settings_.channels, 0);
+    if (samples < 0) {
+      PLOG_ERROR << "Failed to opus_decode_float: result=" << samples;
+      return;
+    }
+
+    // デコードされたデータを AudioFrame に変換
+    AudioFrame frame;
+    frame.sample_rate = settings_.sample_rate;
+    frame.timestamp = encoded.timestamp;
+    frame.pcm = CreatePCMFloat(samples, settings_.channels);
+    
+    // PCMデータをコピー
+    // frame.pcm.data() で生のポインタを取得
+    float* pcm_data = static_cast<float*>(frame.pcm.data());
+    memcpy(pcm_data, pcm_buf_.data(), samples * settings_.channels * sizeof(float));
+
+    if (on_decode_) {
+      on_decode_(frame);
+    }
+  }
+
+  void SetOnDecode(
+      std::function<void(const AudioFrame&)> on_decode) override {
+    on_decode_ = on_decode;
+  }
+
+ private:
+  Settings settings_;
+
+  OpusDecoder* decoder_ = nullptr;
+  std::function<void(const AudioFrame&)> on_decode_;
+  std::vector<float> pcm_buf_;
+};
+
+std::shared_ptr<AudioDecoder> CreateOpusAudioDecoder() {
+  return std::make_shared<OpusAudioDecoder>();
+}

--- a/src/opus_audio_decoder.h
+++ b/src/opus_audio_decoder.h
@@ -1,0 +1,8 @@
+#ifndef LIBDATACHANNEL_OPUS_AUDIO_DECODER_H_INCLUDED
+#define LIBDATACHANNEL_OPUS_AUDIO_DECODER_H_INCLUDED
+
+#include "audio_codec.h"
+
+std::shared_ptr<AudioDecoder> CreateOpusAudioDecoder();
+
+#endif

--- a/tests/test_audio_codec.py
+++ b/tests/test_audio_codec.py
@@ -4,9 +4,11 @@ import numpy as np
 
 from libdatachannel.codec import (
     AudioCodecType,
+    AudioDecoder,
     AudioEncoder,
     AudioFrame,
     EncodedAudio,
+    create_opus_audio_decoder,
     create_opus_audio_encoder,
 )
 
@@ -70,3 +72,141 @@ def test_audio_encoder_encode():
     ]
 
     encoder.release()
+
+
+def test_audio_encoder_decoder_simple():
+    # まずエンコーダーのみのテスト
+    encoder = create_opus_audio_encoder()
+    encoder_settings = AudioEncoder.Settings()
+    encoder_settings.codec_type = AudioCodecType.OPUS
+    encoder_settings.sample_rate = 48000
+    encoder_settings.channels = 2
+    encoder_settings.bitrate = 64000
+    encoder_settings.frame_duration_ms = 20
+    assert encoder.init(encoder_settings) is True
+
+    encoded_data = []
+
+    def on_encoded(encoded: EncodedAudio):
+        print(f"Encoded data size: {len(encoded.data)}")
+        encoded_data.append(encoded)
+
+    encoder.set_on_encode(on_encoded)
+
+    # 簡単なテストデータ
+    frame = AudioFrame()
+    frame.sample_rate = 48000
+    frame.timestamp = timedelta(milliseconds=0)
+    frame.pcm = np.zeros((960, 2), dtype=np.float32)
+
+    encoder.encode(frame)
+    assert len(encoded_data) == 1
+
+    encoder.release()
+
+
+def test_audio_decoder_only():
+    # デコーダーのみのテスト
+    decoder = create_opus_audio_decoder()
+    decoder_settings = AudioDecoder.Settings()
+    decoder_settings.codec_type = AudioCodecType.OPUS
+    decoder_settings.sample_rate = 48000
+    decoder_settings.channels = 2
+    assert decoder.init(decoder_settings) is True
+
+    # まずエンコーダーでデータを作成
+    encoder = create_opus_audio_encoder()
+    encoder_settings = AudioEncoder.Settings()
+    encoder_settings.codec_type = AudioCodecType.OPUS
+    encoder_settings.sample_rate = 48000
+    encoder_settings.channels = 2
+    encoder_settings.bitrate = 64000
+    encoder_settings.frame_duration_ms = 20
+    assert encoder.init(encoder_settings) is True
+
+    encoded_data = []
+
+    def on_encoded(encoded: EncodedAudio):
+        encoded_data.append(encoded)
+
+    encoder.set_on_encode(on_encoded)
+
+    # シンプルなデータでエンコード
+    frame = AudioFrame()
+    frame.sample_rate = 48000
+    frame.timestamp = timedelta(milliseconds=0)
+    frame.pcm = np.zeros((960, 2), dtype=np.float32)
+
+    encoder.encode(frame)
+    encoder.release()
+
+    print(f"Encoded data count: {len(encoded_data)}")
+    assert len(encoded_data) == 1
+
+    # デコード結果を格納
+    decoded_frames = []
+
+    def on_decoded(frame: AudioFrame):
+        print(f"Decoded frame: samples={frame.samples()}, channels={frame.channels()}")
+        decoded_frames.append(frame)
+
+    decoder.set_on_decode(on_decoded)
+
+    # デコード実行
+    print(f"Decoding data with size: {len(encoded_data[0].data)}")
+    decoder.decode(encoded_data[0])
+
+    assert len(decoded_frames) == 1
+    decoder.release()
+
+
+def test_audio_encoder_decoder():
+    # エンコード→デコードのテスト（ゼロデータで確実に動作することを確認）
+    encoder = create_opus_audio_encoder()
+    encoder_settings = AudioEncoder.Settings()
+    encoder_settings.codec_type = AudioCodecType.OPUS
+    encoder_settings.sample_rate = 48000
+    encoder_settings.channels = 2
+    encoder_settings.bitrate = 64000
+    encoder_settings.frame_duration_ms = 20
+    assert encoder.init(encoder_settings) is True
+
+    decoder = create_opus_audio_decoder()
+    decoder_settings = AudioDecoder.Settings()
+    decoder_settings.codec_type = AudioCodecType.OPUS
+    decoder_settings.sample_rate = 48000
+    decoder_settings.channels = 2
+    assert decoder.init(decoder_settings) is True
+
+    encoded_data = []
+    decoded_frames = []
+
+    def on_encoded(encoded: EncodedAudio):
+        encoded_data.append(encoded)
+
+    def on_decoded(frame: AudioFrame):
+        decoded_frames.append(frame)
+
+    encoder.set_on_encode(on_encoded)
+    decoder.set_on_decode(on_decoded)
+
+    # 無音データでテスト
+    frame = AudioFrame()
+    frame.sample_rate = 48000
+    frame.timestamp = timedelta(milliseconds=0)
+    frame.pcm = np.zeros((960, 2), dtype=np.float32)
+
+    encoder.encode(frame)
+    assert len(encoded_data) == 1
+
+    decoder.decode(encoded_data[0])
+    assert len(decoded_frames) == 1
+
+    decoded_frame = decoded_frames[0]
+    assert decoded_frame.sample_rate == 48000
+    assert decoded_frame.channels() == 2
+    assert decoded_frame.samples() == 960
+    assert decoded_frame.timestamp == timedelta(milliseconds=0)
+
+    encoder.release()
+    decoder.release()


### PR DESCRIPTION
This pull request introduces support for audio decoding functionality, specifically for the Opus codec, alongside corresponding tests to ensure proper integration and functionality. The most important changes include the addition of the `AudioDecoder` class, implementation of the Opus audio decoder, and integration of the decoder into the existing codec binding and testing framework.

### Audio Decoder Implementation:
* Added `AudioDecoder` class with methods for initialization, release, decoding, and callback handling (`src/audio_codec.h`).
* Implemented `OpusAudioDecoder` class, providing Opus-specific decoding logic, including buffer management and error handling (`src/opus_audio_decoder.cpp`).
* Added header file `opus_audio_decoder.h` to define the `CreateOpusAudioDecoder` function (`src/opus_audio_decoder.h`).

### Codec Integration:
* Updated `CMakeLists.txt` to include `opus_audio_decoder.cpp` in the build process (`CMakeLists.txt`).
* Integrated `AudioDecoder` and its settings into the codec binding, enabling Python access to the decoder functionality (`src/bind_codec.cpp`).
* Included `opus_audio_decoder.h` in the codec binding file (`src/bind_codec.cpp`).

### Testing Framework:
* Enhanced `test_audio_codec.py` with tests for the `AudioDecoder` functionality, including standalone decoding tests and end-to-end encoding-decoding validation (`tests/test_audio_codec.py`).
* Imported `AudioDecoder` and `create_opus_audio_decoder` into the Python testing framework (`tests/test_audio_codec.py`).