### PR TITLE
[Claude Code] OpenH264 デコーダーを追加する

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ nanobind_add_module(
   src/bind_libyuv.cpp
   src/libdatachannel_ext.cpp
   src/openh264_video_encoder.cpp
+  src/openh264_video_decoder.cpp
   src/opus_audio_encoder.cpp
   src/video_codec.cpp
   src/videotoolbox_video_encoder.cpp

--- a/src/bind_codec.cpp
+++ b/src/bind_codec.cpp
@@ -16,6 +16,7 @@
 #include "aom_video_encoder.h"
 #include "audio_codec.h"
 #include "openh264_video_encoder.h"
+#include "openh264_video_decoder.h"
 #include "opus_audio_encoder.h"
 #include "video_codec.h"
 #include "videotoolbox_video_encoder.h"
@@ -108,6 +109,21 @@ void bind_video_codec(nb::module_& m) {
         "openh264"_a);
   m.def("create_videotoolbox_video_encoder", &CreateVideoToolboxVideoEncoder);
   m.def("create_aom_video_encoder", &CreateAOMVideoEncoder);
+
+  // VideoDecoder
+  nb::class_<VideoDecoder> decoder(m, "VideoDecoder");
+  decoder.def("init", &VideoDecoder::Init)
+      .def("release", &VideoDecoder::Release)
+      .def("decode", &VideoDecoder::Decode)
+      .def("set_on_decode", &VideoDecoder::SetOnDecode);
+
+  // VideoDecoder::Settings
+  nb::class_<VideoDecoder::Settings>(decoder, "Settings")
+      .def(nb::init<>())
+      .def_rw("codec_type", &VideoDecoder::Settings::codec_type);
+
+  m.def("create_openh264_video_decoder", &CreateOpenH264VideoDecoder,
+        "openh264"_a);
 }
 
 void bind_audio_codec(nb::module_& m) {

--- a/src/openh264_video_decoder.cpp
+++ b/src/openh264_video_decoder.cpp
@@ -1,0 +1,202 @@
+#include "openh264_video_decoder.h"
+
+#include <dlfcn.h>
+#include <stdint.h>
+#include <algorithm>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+
+// plog
+#include <plog/Log.h>
+
+// OpenH264
+#include <wels/codec_api.h>
+#include <wels/codec_app_def.h>
+#include <wels/codec_def.h>
+
+class OpenH264VideoDecoder : public VideoDecoder {
+ public:
+  OpenH264VideoDecoder(const std::string& openh264);
+  ~OpenH264VideoDecoder();
+
+  // VideoDecoder interface
+  bool Init(const Settings& settings) override;
+  void Release() override;
+  void Decode(const EncodedImage& encoded_image) override;
+  void SetOnDecode(std::function<void(const VideoFrame&)> on_decode) override;
+
+ private:
+  bool InitOpenH264(const std::string& openh264);
+  void ReleaseOpenH264();
+
+  void* openh264_handle_ = nullptr;
+  ISVCDecoder* decoder_ = nullptr;
+  std::function<void(const VideoFrame&)> on_decode_;
+
+  // Function pointers
+  using CreateDecoderFunc = int (*)(ISVCDecoder**);
+  using DestroyDecoderFunc = void (*)(ISVCDecoder*);
+  CreateDecoderFunc create_decoder_ = nullptr;
+  DestroyDecoderFunc destroy_decoder_ = nullptr;
+};
+
+OpenH264VideoDecoder::OpenH264VideoDecoder(const std::string& openh264) {
+  bool result = InitOpenH264(openh264);
+  if (!result) {
+    throw std::runtime_error("Failed to load OpenH264");
+  }
+}
+
+OpenH264VideoDecoder::~OpenH264VideoDecoder() {
+  Release();
+  ReleaseOpenH264();
+}
+
+bool OpenH264VideoDecoder::InitOpenH264(const std::string& openh264) {
+  void* handle = dlopen(openh264.c_str(), RTLD_LAZY);
+  if (handle == nullptr) {
+    PLOG_ERROR << "Failed to open OpenH264 library: " << dlerror();
+    return false;
+  }
+  
+  create_decoder_ = (CreateDecoderFunc)dlsym(handle, "WelsCreateDecoder");
+  if (create_decoder_ == nullptr) {
+    dlclose(handle);
+    return false;
+  }
+  
+  destroy_decoder_ = (DestroyDecoderFunc)dlsym(handle, "WelsDestroyDecoder");
+  if (destroy_decoder_ == nullptr) {
+    dlclose(handle);
+    return false;
+  }
+  
+  openh264_handle_ = handle;
+  return true;
+}
+
+void OpenH264VideoDecoder::ReleaseOpenH264() {
+  if (openh264_handle_ != nullptr) {
+    dlclose(openh264_handle_);
+    openh264_handle_ = nullptr;
+  }
+}
+
+bool OpenH264VideoDecoder::Init(const Settings& settings) {
+  if (settings.codec_type != VideoCodecType::H264) {
+    PLOG_ERROR << "OpenH264VideoDecoder: Unsupported codec type";
+    return false;
+  }
+
+  Release();
+
+  int rv = create_decoder_(&decoder_);
+  if (rv != 0 || decoder_ == nullptr) {
+    PLOG_ERROR << "OpenH264VideoDecoder: Failed to create decoder";
+    return false;
+  }
+
+  SDecodingParam decoding_param = {0};
+  decoding_param.uiTargetDqLayer = UCHAR_MAX;
+  decoding_param.eEcActiveIdc = ERROR_CON_FRAME_COPY;
+  decoding_param.sVideoProperty.eVideoBsType = VIDEO_BITSTREAM_DEFAULT;
+
+  rv = decoder_->Initialize(&decoding_param);
+  if (rv != 0) {
+    PLOG_ERROR << "OpenH264VideoDecoder: Failed to initialize decoder";
+    destroy_decoder_(decoder_);
+    decoder_ = nullptr;
+    return false;
+  }
+
+  return true;
+}
+
+void OpenH264VideoDecoder::Release() {
+  if (decoder_ != nullptr) {
+    decoder_->Uninitialize();
+    destroy_decoder_(decoder_);
+    decoder_ = nullptr;
+  }
+}
+
+void OpenH264VideoDecoder::Decode(const EncodedImage& encoded_image) {
+  if (decoder_ == nullptr || !on_decode_) {
+    PLOG_ERROR << "OpenH264VideoDecoder: decoder_ or on_decode_ is null";
+    return;
+  }
+
+  uint8_t* dst[3] = {nullptr, nullptr, nullptr};
+  SBufferInfo dst_info = {0};
+
+  PLOG_INFO << "OpenH264VideoDecoder: Decoding " << encoded_image.data.size() << " bytes";
+
+  DECODING_STATE rv = decoder_->DecodeFrame2(
+      encoded_image.data.data(), encoded_image.data.size(), dst, &dst_info);
+
+  PLOG_INFO << "OpenH264VideoDecoder: DecodeFrame2 returned " << rv << ", iBufferStatus=" << dst_info.iBufferStatus;
+
+  if (rv != dsErrorFree && rv != dsNoParamSets) {
+    PLOG_WARNING << "OpenH264VideoDecoder: Decode error: " << rv;
+    return;
+  }
+
+  // バッファステータスが0の場合は、デコードが完了していない（パラメータセットのみ等）
+  if (dst_info.iBufferStatus == 0) {
+    PLOG_INFO << "OpenH264VideoDecoder: No frame output yet (buffering)";
+    return;
+  }
+
+  if (dst_info.iBufferStatus == 1) {
+    // デコード成功
+    int width = dst_info.UsrData.sSystemBuffer.iWidth;
+    int height = dst_info.UsrData.sSystemBuffer.iHeight;
+    int y_stride = dst_info.UsrData.sSystemBuffer.iStride[0];
+    int uv_stride = dst_info.UsrData.sSystemBuffer.iStride[1];
+
+    auto i420_buffer = VideoFrameBufferI420::Create(width, height);
+
+    // Y平面のコピー
+    uint8_t* src_y = dst[0];
+    uint8_t* dst_y = (uint8_t*)i420_buffer->y.data();
+    for (int i = 0; i < height; i++) {
+      memcpy(dst_y + i * width, src_y + i * y_stride, width);
+    }
+
+    // U平面のコピー
+    uint8_t* src_u = dst[1];
+    uint8_t* dst_u = (uint8_t*)i420_buffer->u.data();
+    for (int i = 0; i < height / 2; i++) {
+      memcpy(dst_u + i * width / 2, src_u + i * uv_stride, width / 2);
+    }
+
+    // V平面のコピー
+    uint8_t* src_v = dst[2];
+    uint8_t* dst_v = (uint8_t*)i420_buffer->v.data();
+    for (int i = 0; i < height / 2; i++) {
+      memcpy(dst_v + i * width / 2, src_v + i * uv_stride, width / 2);
+    }
+
+    VideoFrame frame;
+    frame.format = ImageFormat::I420;
+    frame.i420_buffer = i420_buffer;
+    frame.timestamp = encoded_image.timestamp;
+    frame.rid = encoded_image.rid;
+    frame.base_width = width;
+    frame.base_height = height;
+
+    on_decode_(frame);
+  }
+}
+
+void OpenH264VideoDecoder::SetOnDecode(
+    std::function<void(const VideoFrame&)> on_decode) {
+  on_decode_ = on_decode;
+}
+
+std::shared_ptr<VideoDecoder> CreateOpenH264VideoDecoder(
+    const std::string& openh264) {
+  return std::make_shared<OpenH264VideoDecoder>(openh264);
+}

--- a/src/openh264_video_decoder.h
+++ b/src/openh264_video_decoder.h
@@ -1,0 +1,12 @@
+#ifndef LIBDATACHANNEL_OPENH264_VIDEO_DECODER_H_INCLUDED
+#define LIBDATACHANNEL_OPENH264_VIDEO_DECODER_H_INCLUDED
+
+#include <memory>
+#include <string>
+
+#include "video_codec.h"
+
+std::shared_ptr<VideoDecoder> CreateOpenH264VideoDecoder(
+    const std::string& openh264);
+
+#endif

--- a/src/video_codec.h
+++ b/src/video_codec.h
@@ -119,4 +119,19 @@ class VideoEncoder {
       std::function<void(const EncodedImage&)> on_encode) = 0;
 };
 
+class VideoDecoder {
+ public:
+  struct Settings {
+    VideoCodecType codec_type;
+  };
+
+  virtual ~VideoDecoder() = default;
+
+  virtual bool Init(const Settings& settings) = 0;
+  virtual void Release() = 0;
+  virtual void Decode(const EncodedImage& encoded_image) = 0;
+  virtual void SetOnDecode(
+      std::function<void(const VideoFrame&)> on_decode) = 0;
+};
+
 #endif

--- a/tests/test_video_codec.py
+++ b/tests/test_video_codec.py
@@ -5,16 +5,22 @@ from datetime import timedelta
 import numpy as np
 import pytest
 
+from libdatachannel import (
+    NalUnit,
+    NalUnitFragmentA,
+)
 from libdatachannel.codec import (
     EncodedImage,
     ImageFormat,
     VideoCodecType,
+    VideoDecoder,
     VideoEncoder,
     VideoFrame,
     VideoFrameBufferBGR888,
     VideoFrameBufferI420,
     VideoFrameBufferNV12,
     create_aom_video_encoder,
+    create_openh264_video_decoder,
     create_openh264_video_encoder,
     create_videotoolbox_video_encoder,
 )
@@ -200,3 +206,205 @@ def test_aom():
     encoder.encode(frame)
     encoder.release()
     assert on_encode_called
+
+
+def test_openh264_encode_decode():
+    """OpenH264を使用してnumpyで生成した映像をエンコード・デコードするテスト"""
+    openh264 = os.environ.get("OPENH264_PATH")
+    assert openh264 is not None
+
+    # エンコーダーの初期化
+    encoder = create_openh264_video_encoder(openh264)
+    settings = VideoEncoder.Settings()
+    settings.codec_type = VideoCodecType.H264
+    settings.width = 320
+    settings.height = 240
+    settings.bitrate = 500000
+    settings.fps = 30
+    success = encoder.init(settings)
+    assert success
+
+    # テスト用の映像フレームを生成（グラデーションパターン）
+    width, height = 320, 240
+    i420_buffer = VideoFrameBufferI420.create(width, height)
+
+    # Y平面：グラデーション（左から右へ明るくなる）
+    y_gradient = np.linspace(16, 235, width, dtype=np.uint8)
+    y_plane = y_gradient[np.newaxis, :].repeat(height, axis=0)
+    i420_buffer.y[:, :] = y_plane
+
+    # U,V平面：単色（グレー）
+    i420_buffer.u[:, :] = 128
+    i420_buffer.v[:, :] = 128
+
+    frame = VideoFrame()
+    frame.i420_buffer = i420_buffer
+    frame.format = ImageFormat.I420
+    frame.base_width = width
+    frame.base_height = height
+    frame.timestamp = timedelta(microseconds=0)
+
+    encoded_frames = []
+
+    def on_encode(encoded_image):
+        encoded_frames.append(
+            {"data": encoded_image.data.copy(), "timestamp": encoded_image.timestamp}
+        )
+        assert encoded_image.data.size > 0
+
+    encoder.set_on_encode(on_encode)
+    encoder.force_intra_next_frame()  # キーフレームを生成
+    encoder.encode(frame)
+
+    # 2フレーム目も送信（デコーダーが最初のフレームを出力するため）
+    frame.timestamp = timedelta(microseconds=33333)  # 30fps
+    encoder.encode(frame)
+    encoder.release()
+
+    assert len(encoded_frames) >= 1
+    print(f"Encoded {len(encoded_frames)} frames")
+
+    # デコーダーでデコード
+    decoder = create_openh264_video_decoder(openh264)
+    decoder_settings = VideoDecoder.Settings()
+    decoder_settings.codec_type = VideoCodecType.H264
+    success = decoder.init(decoder_settings)
+    assert success
+
+    decoded_frame = None
+
+    def on_decode(video_frame):
+        nonlocal decoded_frame
+        decoded_frame = video_frame
+        print(f"Decoded frame: {video_frame.width()}x{video_frame.height()}")
+
+    decoder.set_on_decode(on_decode)
+
+    # すべてのエンコード済みフレームをデコード
+    for i, encoded in enumerate(encoded_frames):
+        encoded_image = EncodedImage()
+        encoded_image.data = encoded["data"]
+        encoded_image.timestamp = encoded["timestamp"]
+        print(f"Decoding frame {i+1}: {encoded_image.data.size} bytes...")
+        decoder.decode(encoded_image)
+
+    decoder.release()
+
+    assert decoded_frame is not None
+    assert decoded_frame.width() == width
+    assert decoded_frame.height() == height
+    assert decoded_frame.format == ImageFormat.I420
+    # タイムスタンプは最初か2番目のフレームのもの
+    assert decoded_frame.timestamp in [timedelta(microseconds=0), timedelta(microseconds=33333)]
+
+    # デコードされたフレームの内容を簡単に検証
+    # Y平面の最初と最後の値がグラデーションになっているか確認
+    decoded_y = decoded_frame.i420_buffer.y.reshape(height, width)
+    assert decoded_y[0, 0] < decoded_y[0, -1]  # 左端より右端の方が明るい
+
+
+def test_openh264_with_nal_units():
+    """OpenH264とNALユニット解析を使用したテスト"""
+    openh264 = os.environ.get("OPENH264_PATH")
+    assert openh264 is not None
+
+    # エンコーダーの初期化
+    encoder = create_openh264_video_encoder(openh264)
+    settings = VideoEncoder.Settings()
+    settings.codec_type = VideoCodecType.H264
+    settings.width = 320
+    settings.height = 240
+    settings.bitrate = 500000
+    settings.fps = 30
+    success = encoder.init(settings)
+    assert success
+
+    # テスト用の映像フレームを生成（グラデーションパターン）
+    width, height = 320, 240
+    i420_buffer = VideoFrameBufferI420.create(width, height)
+
+    # Y平面：グラデーション（左から右へ明るくなる）
+    y_gradient = np.linspace(16, 235, width, dtype=np.uint8)
+    y_plane = y_gradient[np.newaxis, :].repeat(height, axis=0)
+    i420_buffer.y[:, :] = y_plane
+
+    # U,V平面：単色（グレー）
+    i420_buffer.u[:, :] = 128
+    i420_buffer.v[:, :] = 128
+
+    frame = VideoFrame()
+    frame.i420_buffer = i420_buffer
+    frame.format = ImageFormat.I420
+    frame.base_width = width
+    frame.base_height = height
+    frame.timestamp = timedelta(microseconds=0)
+
+    encoded_frames = []
+
+    def on_encode(encoded_image):
+        encoded_frames.append(
+            {"data": encoded_image.data.copy(), "timestamp": encoded_image.timestamp}
+        )
+
+    encoder.set_on_encode(on_encode)
+    encoder.force_intra_next_frame()  # キーフレームを生成
+    encoder.encode(frame)
+
+    # 2フレーム目も送信
+    frame.timestamp = timedelta(microseconds=33333)
+    encoder.encode(frame)
+    encoder.release()
+
+    assert len(encoded_frames) >= 1
+    print(f"Encoded {len(encoded_frames)} frames")
+
+    # 最初のフレームのNALユニットを解析
+    first_encoded = encoded_frames[0]["data"]
+    print(f"First frame size: {first_encoded.size} bytes")
+
+    # NALユニットを作成して解析
+    nal_unit = NalUnit()
+    nal_unit.set_payload(bytes(first_encoded))
+
+    # NALユニットのヘッダー情報を検証
+    unit_type = nal_unit.unit_type()
+    print(f"NAL unit type: {unit_type}")
+
+    # 複数のNALユニットに分割（フラグメント化）のテスト
+    fragments = NalUnitFragmentA.fragments_from(nal_unit, max_fragment_size=100)
+    print(f"Generated {len(fragments)} fragments")
+
+    # デコーダーでデコード
+    decoder = create_openh264_video_decoder(openh264)
+    decoder_settings = VideoDecoder.Settings()
+    decoder_settings.codec_type = VideoCodecType.H264
+    success = decoder.init(decoder_settings)
+    assert success
+
+    decoded_frame = None
+
+    def on_decode(video_frame):
+        nonlocal decoded_frame
+        decoded_frame = video_frame
+        print(f"Decoded frame: {video_frame.width()}x{video_frame.height()}")
+
+    decoder.set_on_decode(on_decode)
+
+    # すべてのエンコード済みフレームをデコード
+    for i, encoded in enumerate(encoded_frames):
+        encoded_image = EncodedImage()
+        encoded_image.data = encoded["data"]
+        encoded_image.timestamp = encoded["timestamp"]
+        print(f"Decoding frame {i+1}: {encoded_image.data.size} bytes...")
+        decoder.decode(encoded_image)
+
+    decoder.release()
+
+    # デコード結果の検証
+    assert decoded_frame is not None
+    assert decoded_frame.width() == width
+    assert decoded_frame.height() == height
+
+    # デコードされたフレームの内容を簡単に検証
+    decoded_y = decoded_frame.i420_buffer.y.reshape(height, width)
+    assert decoded_y[0, 0] < decoded_y[0, -1]  # 左端より右端の方が明るい

--- a/tests/test_video_codec.py
+++ b/tests/test_video_codec.py
@@ -242,26 +242,24 @@ def test_openh264_encode_decode():
     frame.format = ImageFormat.I420
     frame.base_width = width
     frame.base_height = height
-    frame.timestamp = timedelta(microseconds=0)
+    frame.timestamp = timedelta(microseconds=1000)
 
     encoded_frames = []
 
     def on_encode(encoded_image):
-        encoded_frames.append(
-            {"data": encoded_image.data.copy(), "timestamp": encoded_image.timestamp}
-        )
+        encoded_frames.append(encoded_image)
         assert encoded_image.data.size > 0
 
     encoder.set_on_encode(on_encode)
     encoder.force_intra_next_frame()  # キーフレームを生成
     encoder.encode(frame)
 
-    # 2フレーム目も送信（デコーダーが最初のフレームを出力するため）
-    frame.timestamp = timedelta(microseconds=33333)  # 30fps
+    # 2フレーム目も送信
+    frame.timestamp = timedelta(microseconds=1000 + 33333)  # 30fps
     encoder.encode(frame)
     encoder.release()
 
-    assert len(encoded_frames) >= 1
+    assert len(encoded_frames) == 2
     print(f"Encoded {len(encoded_frames)} frames")
 
     # デコーダーでデコード
@@ -271,11 +269,11 @@ def test_openh264_encode_decode():
     success = decoder.init(decoder_settings)
     assert success
 
-    decoded_frame = None
+    decoded_frames = []
 
     def on_decode(video_frame):
-        nonlocal decoded_frame
-        decoded_frame = video_frame
+        nonlocal decoded_frames
+        decoded_frames.append(video_frame)
         print(f"Decoded frame: {video_frame.width()}x{video_frame.height()}")
 
     decoder.set_on_decode(on_decode)
@@ -283,23 +281,26 @@ def test_openh264_encode_decode():
     # すべてのエンコード済みフレームをデコード
     for i, encoded in enumerate(encoded_frames):
         encoded_image = EncodedImage()
-        encoded_image.data = encoded["data"]
-        encoded_image.timestamp = encoded["timestamp"]
-        print(f"Decoding frame {i+1}: {encoded_image.data.size} bytes...")
+        encoded_image.data = encoded.data
+        encoded_image.timestamp = encoded.timestamp
+        print(f"Decoding frame {i + 1}: {encoded_image.data.size} bytes...")
         decoder.decode(encoded_image)
 
     decoder.release()
 
-    assert decoded_frame is not None
-    assert decoded_frame.width() == width
-    assert decoded_frame.height() == height
-    assert decoded_frame.format == ImageFormat.I420
-    # タイムスタンプは最初か2番目のフレームのもの
-    assert decoded_frame.timestamp in [timedelta(microseconds=0), timedelta(microseconds=33333)]
+    assert len(decoded_frames) == 2
+    assert decoded_frames[0].width() == width
+    assert decoded_frames[0].height() == height
+    assert decoded_frames[0].format == ImageFormat.I420
+    assert decoded_frames[0].timestamp == timedelta(microseconds=1000)
+    assert decoded_frames[1].width() == width
+    assert decoded_frames[1].height() == height
+    assert decoded_frames[1].format == ImageFormat.I420
+    assert decoded_frames[1].timestamp == timedelta(microseconds=1000 + 33333)
 
     # デコードされたフレームの内容を簡単に検証
     # Y平面の最初と最後の値がグラデーションになっているか確認
-    decoded_y = decoded_frame.i420_buffer.y.reshape(height, width)
+    decoded_y = decoded_frames[0].i420_buffer.y.reshape(height, width)
     assert decoded_y[0, 0] < decoded_y[0, -1]  # 左端より右端の方が明るい
 
 
@@ -337,41 +338,42 @@ def test_openh264_with_nal_units():
     frame.format = ImageFormat.I420
     frame.base_width = width
     frame.base_height = height
-    frame.timestamp = timedelta(microseconds=0)
+    frame.timestamp = timedelta(microseconds=1000)
 
     encoded_frames = []
 
     def on_encode(encoded_image):
-        encoded_frames.append(
-            {"data": encoded_image.data.copy(), "timestamp": encoded_image.timestamp}
-        )
+        encoded_frames.append(encoded_image)
 
     encoder.set_on_encode(on_encode)
     encoder.force_intra_next_frame()  # キーフレームを生成
     encoder.encode(frame)
 
     # 2フレーム目も送信
-    frame.timestamp = timedelta(microseconds=33333)
+    frame.timestamp = timedelta(microseconds=1000 + 33333)
     encoder.encode(frame)
     encoder.release()
 
-    assert len(encoded_frames) >= 1
+    assert len(encoded_frames) == 2
     print(f"Encoded {len(encoded_frames)} frames")
 
     # 最初のフレームのNALユニットを解析
-    first_encoded = encoded_frames[0]["data"]
+    first_encoded = encoded_frames[0].data
     print(f"First frame size: {first_encoded.size} bytes")
 
-    # NALユニットを作成して解析
-    nal_unit = NalUnit()
-    nal_unit.set_payload(bytes(first_encoded))
+    # NALユニットを分割して作成
+    nal_units_byte = bytes(first_encoded).split(b"\x00\x00\x00\x01")[1:]
+    nal_units = list(map(lambda b: NalUnit(b), nal_units_byte))
 
     # NALユニットのヘッダー情報を検証
-    unit_type = nal_unit.unit_type()
-    print(f"NAL unit type: {unit_type}")
+    assert len(nal_units) == 3
+    assert nal_units[0].unit_type() == 7  # SPS
+    assert nal_units[1].unit_type() == 8  # PPS
+    assert nal_units[2].unit_type() == 5  # IDR
 
     # 複数のNALユニットに分割（フラグメント化）のテスト
-    fragments = NalUnitFragmentA.fragments_from(nal_unit, max_fragment_size=100)
+    fragments = NalUnitFragmentA.fragments_from(nal_units[2], max_fragment_size=100)
+    assert len(fragments) == 5
     print(f"Generated {len(fragments)} fragments")
 
     # デコーダーでデコード
@@ -381,11 +383,11 @@ def test_openh264_with_nal_units():
     success = decoder.init(decoder_settings)
     assert success
 
-    decoded_frame = None
+    decoded_frames = []
 
     def on_decode(video_frame):
-        nonlocal decoded_frame
-        decoded_frame = video_frame
+        nonlocal decoded_frames
+        decoded_frames.append(video_frame)
         print(f"Decoded frame: {video_frame.width()}x{video_frame.height()}")
 
     decoder.set_on_decode(on_decode)
@@ -393,18 +395,22 @@ def test_openh264_with_nal_units():
     # すべてのエンコード済みフレームをデコード
     for i, encoded in enumerate(encoded_frames):
         encoded_image = EncodedImage()
-        encoded_image.data = encoded["data"]
-        encoded_image.timestamp = encoded["timestamp"]
-        print(f"Decoding frame {i+1}: {encoded_image.data.size} bytes...")
+        encoded_image.data = encoded.data
+        encoded_image.timestamp = encoded.timestamp
+        print(f"Decoding frame {i + 1}: {encoded_image.data.size} bytes...")
         decoder.decode(encoded_image)
 
     decoder.release()
 
     # デコード結果の検証
-    assert decoded_frame is not None
-    assert decoded_frame.width() == width
-    assert decoded_frame.height() == height
+    assert len(decoded_frames) == 2
+    assert decoded_frames[0].width() == width
+    assert decoded_frames[0].height() == height
+    assert decoded_frames[0].timestamp == timedelta(microseconds=1000)
+    assert decoded_frames[1].width() == width
+    assert decoded_frames[1].height() == height
+    assert decoded_frames[1].timestamp == timedelta(microseconds=1000 + 33333)
 
     # デコードされたフレームの内容を簡単に検証
-    decoded_y = decoded_frame.i420_buffer.y.reshape(height, width)
+    decoded_y = decoded_frames[0].i420_buffer.y.reshape(height, width)
     assert decoded_y[0, 0] < decoded_y[0, -1]  # 左端より右端の方が明るい


### PR DESCRIPTION
Opus デコーダーブランチをベースにしているので、 https://github.com/shiguredo/libdatachannel-py/pull/5 をマージできてからマージしてください。

---

This pull request introduces support for OpenH264 video decoding, including the implementation of a new `VideoDecoder` class, integration with existing video codec bindings, and comprehensive tests. The most important changes include the addition of the OpenH264 decoder implementation, updates to the codec bindings, and new test cases for encoding and decoding workflows.

### OpenH264 Decoder Implementation:
* Added `OpenH264VideoDecoder` class in `src/openh264_video_decoder.cpp` to provide decoding functionality, including methods for initialization, release, decoding, and setting callback functions for decoded frames.
* Defined the corresponding header file `src/openh264_video_decoder.h` with the `CreateOpenH264VideoDecoder` factory function.

### Video Codec Integration:
* Introduced a new `VideoDecoder` interface in `src/video_codec.h` to standardize video decoding operations, including settings for codec type and callback functions.
* Updated `CMakeLists.txt` to include `src/openh264_video_decoder.cpp` in the build process.
* Updated `src/bind_codec.cpp` to bind the `VideoDecoder` class and its methods to the module, enabling Python integration.
* Added the `create_openh264_video_decoder` function to codec bindings in `src/bind_codec.cpp`.

### Testing Enhancements:
* Extended `tests/test_video_codec.py` with two new test cases:
  - [`test_openh264_encode_decode`](diffhunk://#diff-15c8585be12e05a245359253abbc2afc9b59243437c16fe46f6a86d28a73b3b4R209-R410): Tests encoding and decoding using OpenH264 with gradient video frames.
  - [`test_openh264_with_nal_units`](diffhunk://#diff-15c8585be12e05a245359253abbc2afc9b59243437c16fe46f6a86d28a73b3b4R209-R410): Tests NAL unit analysis and decoding with OpenH264.
* Updated imports in `tests/test_video_codec.py` to include `VideoDecoder` and related functions.