### PR TITLE
[Claude Code] libaom のデコーダーを追加する

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ add_subdirectory(${LIBDATACHANNEL_DIR}/deps/json json EXCLUDE_FROM_ALL)
 nanobind_add_module(
   libdatachannel_ext
   NB_STATIC
+  src/aom_video_decoder.cpp
   src/aom_video_encoder.cpp
   src/audio_codec.cpp
   src/bind_codec.cpp

--- a/src/aom_video_decoder.cpp
+++ b/src/aom_video_decoder.cpp
@@ -14,131 +14,110 @@
 #include <aom/aom_decoder.h>
 #include <aom/aomdx.h>
 
+// libyuv
+#include <libyuv.h>
+
 class AomVideoDecoder : public VideoDecoder {
  public:
-  AomVideoDecoder();
-  ~AomVideoDecoder();
+  AomVideoDecoder() = default;
+  ~AomVideoDecoder() { Release(); }
 
   // VideoDecoder interface
-  bool Init(const Settings& settings) override;
-  void Release() override;
-  void Decode(const EncodedImage& encoded_image) override;
-  void SetOnDecode(std::function<void(const VideoFrame&)> on_decode) override;
+  bool Init(const Settings& settings) override {
+    if (settings.codec_type != VideoCodecType::AV1) {
+      PLOG_ERROR << "AomVideoDecoder: Unsupported codec type";
+      return false;
+    }
+
+    Release();
+
+    aom_codec_dec_cfg_t cfg = {};
+    cfg.threads = 1;  // シングルスレッドで開始
+    cfg.allow_lowbitdepth = 1;
+
+    aom_codec_err_t res =
+        aom_codec_dec_init(&codec_, aom_codec_av1_dx(), &cfg, 0);
+    if (res != AOM_CODEC_OK) {
+      PLOG_ERROR << "AomVideoDecoder: Failed to initialize decoder: "
+                 << aom_codec_err_to_string(res);
+      return false;
+    }
+
+    initialized_ = true;
+    return true;
+  }
+
+  void Release() override {
+    if (initialized_) {
+      aom_codec_destroy(&codec_);
+      initialized_ = false;
+    }
+  }
+
+  void Decode(const EncodedImage& encoded_image) override {
+    if (!initialized_) {
+      PLOG_ERROR << "AomVideoDecoder: decoder not initialized";
+      return;
+    }
+
+    PLOG_DEBUG << "AomVideoDecoder: Decoding " << encoded_image.data.size()
+               << " bytes";
+
+    aom_codec_err_t res = aom_codec_decode(&codec_, encoded_image.data.data(),
+                                           encoded_image.data.size(), nullptr);
+
+    if (res != AOM_CODEC_OK) {
+      PLOG_WARNING << "AomVideoDecoder: Decode error: "
+                   << aom_codec_err_to_string(res);
+      return;
+    }
+
+    aom_codec_iter_t iter = nullptr;
+    aom_image_t* img = nullptr;
+
+    while ((img = aom_codec_get_frame(&codec_, &iter)) != nullptr) {
+      if (img->fmt != AOM_IMG_FMT_I420 && img->fmt != AOM_IMG_FMT_I42016) {
+        PLOG_WARNING << "AomVideoDecoder: Unsupported image format: "
+                     << img->fmt;
+        continue;
+      }
+
+      int width = img->d_w;
+      int height = img->d_h;
+
+      auto i420_buffer = VideoFrameBufferI420::Create(width, height);
+
+      libyuv::I420Copy(img->planes[AOM_PLANE_Y], img->stride[AOM_PLANE_Y],
+                       img->planes[AOM_PLANE_U], img->stride[AOM_PLANE_U],
+                       img->planes[AOM_PLANE_V], img->stride[AOM_PLANE_V],
+                       i420_buffer->y.data(), i420_buffer->stride_y(),
+                       i420_buffer->u.data(), i420_buffer->stride_u(),
+                       i420_buffer->v.data(), i420_buffer->stride_v(), width,
+                       height);
+
+      VideoFrame frame;
+      frame.format = ImageFormat::I420;
+      frame.i420_buffer = i420_buffer;
+      frame.timestamp = encoded_image.timestamp;
+      frame.rid = encoded_image.rid;
+      frame.base_width = width;
+      frame.base_height = height;
+
+      if (on_decode_) {
+        on_decode_(frame);
+      }
+    }
+  }
+
+  void SetOnDecode(std::function<void(const VideoFrame&)> on_decode) override {
+    on_decode_ = on_decode;
+  }
 
  private:
   aom_codec_ctx_t codec_ = {};
   bool initialized_ = false;
   std::function<void(const VideoFrame&)> on_decode_;
 };
-
-AomVideoDecoder::AomVideoDecoder() {
-}
-
-AomVideoDecoder::~AomVideoDecoder() {
-  Release();
-}
-
-bool AomVideoDecoder::Init(const Settings& settings) {
-  if (settings.codec_type != VideoCodecType::AV1) {
-    PLOG_ERROR << "AomVideoDecoder: Unsupported codec type";
-    return false;
-  }
-
-  Release();
-
-  aom_codec_dec_cfg_t cfg = {};
-  cfg.threads = 1;  // シングルスレッドで開始
-  cfg.allow_lowbitdepth = 1;
-
-  aom_codec_err_t res = aom_codec_dec_init(&codec_, aom_codec_av1_dx(), &cfg, 0);
-  if (res != AOM_CODEC_OK) {
-    PLOG_ERROR << "AomVideoDecoder: Failed to initialize decoder: " 
-               << aom_codec_err_to_string(res);
-    return false;
-  }
-
-  initialized_ = true;
-  return true;
-}
-
-void AomVideoDecoder::Release() {
-  if (initialized_) {
-    aom_codec_destroy(&codec_);
-    initialized_ = false;
-  }
-}
-
-void AomVideoDecoder::Decode(const EncodedImage& encoded_image) {
-  if (!initialized_ || !on_decode_) {
-    PLOG_ERROR << "AomVideoDecoder: decoder not initialized or on_decode_ is null";
-    return;
-  }
-
-  PLOG_INFO << "AomVideoDecoder: Decoding " << encoded_image.data.size() << " bytes";
-
-  aom_codec_err_t res = aom_codec_decode(&codec_, encoded_image.data.data(), 
-                                         encoded_image.data.size(), nullptr);
-  
-  if (res != AOM_CODEC_OK) {
-    PLOG_WARNING << "AomVideoDecoder: Decode error: " 
-                 << aom_codec_err_to_string(res);
-    return;
-  }
-
-  aom_codec_iter_t iter = nullptr;
-  aom_image_t* img = nullptr;
-
-  while ((img = aom_codec_get_frame(&codec_, &iter)) != nullptr) {
-    if (img->fmt != AOM_IMG_FMT_I420 && img->fmt != AOM_IMG_FMT_I42016) {
-      PLOG_WARNING << "AomVideoDecoder: Unsupported image format: " << img->fmt;
-      continue;
-    }
-
-    int width = img->d_w;
-    int height = img->d_h;
-
-    auto i420_buffer = VideoFrameBufferI420::Create(width, height);
-
-    // Y平面のコピー
-    uint8_t* src_y = img->planes[AOM_PLANE_Y];
-    uint8_t* dst_y = (uint8_t*)i420_buffer->y.data();
-    int y_stride = img->stride[AOM_PLANE_Y];
-    for (int i = 0; i < height; i++) {
-      memcpy(dst_y + i * width, src_y + i * y_stride, width);
-    }
-
-    // U平面のコピー
-    uint8_t* src_u = img->planes[AOM_PLANE_U];
-    uint8_t* dst_u = (uint8_t*)i420_buffer->u.data();
-    int u_stride = img->stride[AOM_PLANE_U];
-    for (int i = 0; i < height / 2; i++) {
-      memcpy(dst_u + i * width / 2, src_u + i * u_stride, width / 2);
-    }
-
-    // V平面のコピー
-    uint8_t* src_v = img->planes[AOM_PLANE_V];
-    uint8_t* dst_v = (uint8_t*)i420_buffer->v.data();
-    int v_stride = img->stride[AOM_PLANE_V];
-    for (int i = 0; i < height / 2; i++) {
-      memcpy(dst_v + i * width / 2, src_v + i * v_stride, width / 2);
-    }
-
-    VideoFrame frame;
-    frame.format = ImageFormat::I420;
-    frame.i420_buffer = i420_buffer;
-    frame.timestamp = encoded_image.timestamp;
-    frame.rid = encoded_image.rid;
-    frame.base_width = width;
-    frame.base_height = height;
-
-    on_decode_(frame);
-  }
-}
-
-void AomVideoDecoder::SetOnDecode(
-    std::function<void(const VideoFrame&)> on_decode) {
-  on_decode_ = on_decode;
-}
 
 std::shared_ptr<VideoDecoder> CreateAomVideoDecoder() {
   return std::make_shared<AomVideoDecoder>();

--- a/src/aom_video_decoder.cpp
+++ b/src/aom_video_decoder.cpp
@@ -1,0 +1,145 @@
+#include "aom_video_decoder.h"
+
+#include <stdint.h>
+#include <algorithm>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+
+// plog
+#include <plog/Log.h>
+
+// libaom
+#include <aom/aom_decoder.h>
+#include <aom/aomdx.h>
+
+class AomVideoDecoder : public VideoDecoder {
+ public:
+  AomVideoDecoder();
+  ~AomVideoDecoder();
+
+  // VideoDecoder interface
+  bool Init(const Settings& settings) override;
+  void Release() override;
+  void Decode(const EncodedImage& encoded_image) override;
+  void SetOnDecode(std::function<void(const VideoFrame&)> on_decode) override;
+
+ private:
+  aom_codec_ctx_t codec_ = {};
+  bool initialized_ = false;
+  std::function<void(const VideoFrame&)> on_decode_;
+};
+
+AomVideoDecoder::AomVideoDecoder() {
+}
+
+AomVideoDecoder::~AomVideoDecoder() {
+  Release();
+}
+
+bool AomVideoDecoder::Init(const Settings& settings) {
+  if (settings.codec_type != VideoCodecType::AV1) {
+    PLOG_ERROR << "AomVideoDecoder: Unsupported codec type";
+    return false;
+  }
+
+  Release();
+
+  aom_codec_dec_cfg_t cfg = {};
+  cfg.threads = 1;  // シングルスレッドで開始
+  cfg.allow_lowbitdepth = 1;
+
+  aom_codec_err_t res = aom_codec_dec_init(&codec_, aom_codec_av1_dx(), &cfg, 0);
+  if (res != AOM_CODEC_OK) {
+    PLOG_ERROR << "AomVideoDecoder: Failed to initialize decoder: " 
+               << aom_codec_err_to_string(res);
+    return false;
+  }
+
+  initialized_ = true;
+  return true;
+}
+
+void AomVideoDecoder::Release() {
+  if (initialized_) {
+    aom_codec_destroy(&codec_);
+    initialized_ = false;
+  }
+}
+
+void AomVideoDecoder::Decode(const EncodedImage& encoded_image) {
+  if (!initialized_ || !on_decode_) {
+    PLOG_ERROR << "AomVideoDecoder: decoder not initialized or on_decode_ is null";
+    return;
+  }
+
+  PLOG_INFO << "AomVideoDecoder: Decoding " << encoded_image.data.size() << " bytes";
+
+  aom_codec_err_t res = aom_codec_decode(&codec_, encoded_image.data.data(), 
+                                         encoded_image.data.size(), nullptr);
+  
+  if (res != AOM_CODEC_OK) {
+    PLOG_WARNING << "AomVideoDecoder: Decode error: " 
+                 << aom_codec_err_to_string(res);
+    return;
+  }
+
+  aom_codec_iter_t iter = nullptr;
+  aom_image_t* img = nullptr;
+
+  while ((img = aom_codec_get_frame(&codec_, &iter)) != nullptr) {
+    if (img->fmt != AOM_IMG_FMT_I420 && img->fmt != AOM_IMG_FMT_I42016) {
+      PLOG_WARNING << "AomVideoDecoder: Unsupported image format: " << img->fmt;
+      continue;
+    }
+
+    int width = img->d_w;
+    int height = img->d_h;
+
+    auto i420_buffer = VideoFrameBufferI420::Create(width, height);
+
+    // Y平面のコピー
+    uint8_t* src_y = img->planes[AOM_PLANE_Y];
+    uint8_t* dst_y = (uint8_t*)i420_buffer->y.data();
+    int y_stride = img->stride[AOM_PLANE_Y];
+    for (int i = 0; i < height; i++) {
+      memcpy(dst_y + i * width, src_y + i * y_stride, width);
+    }
+
+    // U平面のコピー
+    uint8_t* src_u = img->planes[AOM_PLANE_U];
+    uint8_t* dst_u = (uint8_t*)i420_buffer->u.data();
+    int u_stride = img->stride[AOM_PLANE_U];
+    for (int i = 0; i < height / 2; i++) {
+      memcpy(dst_u + i * width / 2, src_u + i * u_stride, width / 2);
+    }
+
+    // V平面のコピー
+    uint8_t* src_v = img->planes[AOM_PLANE_V];
+    uint8_t* dst_v = (uint8_t*)i420_buffer->v.data();
+    int v_stride = img->stride[AOM_PLANE_V];
+    for (int i = 0; i < height / 2; i++) {
+      memcpy(dst_v + i * width / 2, src_v + i * v_stride, width / 2);
+    }
+
+    VideoFrame frame;
+    frame.format = ImageFormat::I420;
+    frame.i420_buffer = i420_buffer;
+    frame.timestamp = encoded_image.timestamp;
+    frame.rid = encoded_image.rid;
+    frame.base_width = width;
+    frame.base_height = height;
+
+    on_decode_(frame);
+  }
+}
+
+void AomVideoDecoder::SetOnDecode(
+    std::function<void(const VideoFrame&)> on_decode) {
+  on_decode_ = on_decode;
+}
+
+std::shared_ptr<VideoDecoder> CreateAomVideoDecoder() {
+  return std::make_shared<AomVideoDecoder>();
+}

--- a/src/aom_video_decoder.h
+++ b/src/aom_video_decoder.h
@@ -1,0 +1,11 @@
+#ifndef LIBDATACHANNEL_AOM_VIDEO_DECODER_H_INCLUDED
+#define LIBDATACHANNEL_AOM_VIDEO_DECODER_H_INCLUDED
+
+#include <memory>
+#include <string>
+
+#include "video_codec.h"
+
+std::shared_ptr<VideoDecoder> CreateAomVideoDecoder();
+
+#endif

--- a/src/bind_codec.cpp
+++ b/src/bind_codec.cpp
@@ -13,6 +13,7 @@
 #include <nanobind/stl/vector.h>
 #include <nanobind/trampoline.h>
 
+#include "aom_video_decoder.h"
 #include "aom_video_encoder.h"
 #include "audio_codec.h"
 #include "openh264_video_encoder.h"
@@ -124,6 +125,7 @@ void bind_video_codec(nb::module_& m) {
 
   m.def("create_openh264_video_decoder", &CreateOpenH264VideoDecoder,
         "openh264"_a);
+  m.def("create_aom_video_decoder", &CreateAomVideoDecoder);
 }
 
 void bind_audio_codec(nb::module_& m) {

--- a/tests/test_video_codec.py
+++ b/tests/test_video_codec.py
@@ -19,6 +19,7 @@ from libdatachannel.codec import (
     VideoFrameBufferBGR888,
     VideoFrameBufferI420,
     VideoFrameBufferNV12,
+    create_aom_video_decoder,
     create_aom_video_encoder,
     create_openh264_video_decoder,
     create_openh264_video_encoder,
@@ -406,5 +407,97 @@ def test_openh264_with_nal_units():
     assert decoded_frame.height() == height
 
     # デコードされたフレームの内容を簡単に検証
+    decoded_y = decoded_frame.i420_buffer.y.reshape(height, width)
+    assert decoded_y[0, 0] < decoded_y[0, -1]  # 左端より右端の方が明るい
+
+
+def test_aom_encode_decode():
+    """AOMを使用してnumpyで生成した映像をエンコード・デコードするテスト"""
+    # エンコーダーの初期化
+    encoder = create_aom_video_encoder()
+    settings = VideoEncoder.Settings()
+    settings.codec_type = VideoCodecType.AV1
+    settings.width = 320
+    settings.height = 240
+    settings.bitrate = 500000
+    settings.fps = 30
+    success = encoder.init(settings)
+    assert success
+
+    # テスト用の映像フレームを生成（グラデーションパターン）
+    width, height = 320, 240
+    i420_buffer = VideoFrameBufferI420.create(width, height)
+
+    # Y平面：グラデーション（左から右へ明るくなる）
+    y_gradient = np.linspace(16, 235, width, dtype=np.uint8)
+    y_plane = y_gradient[np.newaxis, :].repeat(height, axis=0)
+    i420_buffer.y[:, :] = y_plane
+
+    # U,V平面：単色（グレー）
+    i420_buffer.u[:, :] = 128
+    i420_buffer.v[:, :] = 128
+
+    frame = VideoFrame()
+    frame.i420_buffer = i420_buffer
+    frame.format = ImageFormat.I420
+    frame.base_width = width
+    frame.base_height = height
+    frame.timestamp = timedelta(microseconds=0)
+
+    encoded_frames = []
+
+    def on_encode(encoded_image):
+        encoded_frames.append(
+            {"data": encoded_image.data.copy(), "timestamp": encoded_image.timestamp}
+        )
+        assert encoded_image.data.size > 0
+
+    encoder.set_on_encode(on_encode)
+    encoder.force_intra_next_frame()  # キーフレームを生成
+    encoder.encode(frame)
+
+    # 2フレーム目も送信（デコーダーが最初のフレームを出力するため）
+    frame.timestamp = timedelta(microseconds=33333)  # 30fps
+    encoder.encode(frame)
+    encoder.release()
+
+    assert len(encoded_frames) >= 1
+    print(f"Encoded {len(encoded_frames)} frames")
+
+    # デコーダーでデコード
+    decoder = create_aom_video_decoder()
+    decoder_settings = VideoDecoder.Settings()
+    decoder_settings.codec_type = VideoCodecType.AV1
+    success = decoder.init(decoder_settings)
+    assert success
+
+    decoded_frame = None
+
+    def on_decode(video_frame):
+        nonlocal decoded_frame
+        decoded_frame = video_frame
+        print(f"Decoded frame: {video_frame.width()}x{video_frame.height()}")
+
+    decoder.set_on_decode(on_decode)
+
+    # すべてのエンコード済みフレームをデコード
+    for i, encoded in enumerate(encoded_frames):
+        encoded_image = EncodedImage()
+        encoded_image.data = encoded["data"]
+        encoded_image.timestamp = encoded["timestamp"]
+        print(f"Decoding frame {i+1}: {encoded_image.data.size} bytes...")
+        decoder.decode(encoded_image)
+
+    decoder.release()
+
+    assert decoded_frame is not None
+    assert decoded_frame.width() == width
+    assert decoded_frame.height() == height
+    assert decoded_frame.format == ImageFormat.I420
+    # タイムスタンプは最初か2番目のフレームのもの
+    assert decoded_frame.timestamp in [timedelta(microseconds=0), timedelta(microseconds=33333)]
+
+    # デコードされたフレームの内容を簡単に検証
+    # Y平面の最初と最後の値がグラデーションになっているか確認
     decoded_y = decoded_frame.i420_buffer.y.reshape(height, width)
     assert decoded_y[0, 0] < decoded_y[0, -1]  # 左端より右端の方が明るい

--- a/tests/test_video_codec.py
+++ b/tests/test_video_codec.py
@@ -448,27 +448,28 @@ def test_aom_encode_decode():
     frame.format = ImageFormat.I420
     frame.base_width = width
     frame.base_height = height
-    frame.timestamp = timedelta(microseconds=0)
+    frame.timestamp = timedelta(microseconds=1000)
 
     encoded_frames = []
 
     def on_encode(encoded_image):
-        encoded_frames.append(
-            {"data": encoded_image.data.copy(), "timestamp": encoded_image.timestamp}
-        )
+        encoded_frames.append(encoded_image)
         assert encoded_image.data.size > 0
 
     encoder.set_on_encode(on_encode)
     encoder.force_intra_next_frame()  # キーフレームを生成
     encoder.encode(frame)
 
-    # 2フレーム目も送信（デコーダーが最初のフレームを出力するため）
-    frame.timestamp = timedelta(microseconds=33333)  # 30fps
+    # 2フレーム目も送信
+    frame.timestamp = timedelta(microseconds=1000 + 33333)  # 30fps
     encoder.encode(frame)
     encoder.release()
 
-    assert len(encoded_frames) >= 1
+    assert len(encoded_frames) == 2
     print(f"Encoded {len(encoded_frames)} frames")
+
+    assert encoded_frames[0].timestamp == timedelta(microseconds=1000)
+    assert encoded_frames[1].timestamp == timedelta(microseconds=1000 + 33333)
 
     # デコーダーでデコード
     decoder = create_aom_video_decoder()
@@ -477,11 +478,11 @@ def test_aom_encode_decode():
     success = decoder.init(decoder_settings)
     assert success
 
-    decoded_frame = None
+    decoded_frames = []
 
     def on_decode(video_frame):
-        nonlocal decoded_frame
-        decoded_frame = video_frame
+        nonlocal decoded_frames
+        decoded_frames.append(video_frame)
         print(f"Decoded frame: {video_frame.width()}x{video_frame.height()}")
 
     decoder.set_on_decode(on_decode)
@@ -489,21 +490,24 @@ def test_aom_encode_decode():
     # すべてのエンコード済みフレームをデコード
     for i, encoded in enumerate(encoded_frames):
         encoded_image = EncodedImage()
-        encoded_image.data = encoded["data"]
-        encoded_image.timestamp = encoded["timestamp"]
-        print(f"Decoding frame {i+1}: {encoded_image.data.size} bytes...")
+        encoded_image.data = encoded.data
+        encoded_image.timestamp = encoded.timestamp
+        print(f"Decoding frame {i + 1}: {encoded_image.data.size} bytes...")
         decoder.decode(encoded_image)
 
     decoder.release()
 
-    assert decoded_frame is not None
-    assert decoded_frame.width() == width
-    assert decoded_frame.height() == height
-    assert decoded_frame.format == ImageFormat.I420
-    # タイムスタンプは最初か2番目のフレームのもの
-    assert decoded_frame.timestamp in [timedelta(microseconds=0), timedelta(microseconds=33333)]
+    assert len(decoded_frames) == 2
+    assert decoded_frames[0].width() == width
+    assert decoded_frames[0].height() == height
+    assert decoded_frames[0].format == ImageFormat.I420
+    assert decoded_frames[0].timestamp == timedelta(microseconds=1000)
+    assert decoded_frames[1].width() == width
+    assert decoded_frames[1].height() == height
+    assert decoded_frames[1].format == ImageFormat.I420
+    assert decoded_frames[1].timestamp == timedelta(microseconds=1000 + 33333)
 
     # デコードされたフレームの内容を簡単に検証
     # Y平面の最初と最後の値がグラデーションになっているか確認
-    decoded_y = decoded_frame.i420_buffer.y.reshape(height, width)
+    decoded_y = decoded_frames[0].i420_buffer.y.reshape(height, width)
     assert decoded_y[0, 0] < decoded_y[0, -1]  # 左端より右端の方が明るい


### PR DESCRIPTION
OpenH264 デコーダーブランチをベースにしているので、 https://github.com/shiguredo/libdatachannel-py/pull/6 をマージできてから、マージしてください。

---

This pull request introduces support for video decoding using AOM (AV1 codec) and OpenH264 (H.264 codec) within the `libdatachannel` library. It includes the implementation of new video decoder classes, integration into the codec binding system, and extensive unit tests to validate the functionality.

### Video Decoder Implementation:
* **AOM Video Decoder**: Added `AomVideoDecoder` class for decoding AV1 streams, including initialization, decoding logic, and frame handling. (`src/aom_video_decoder.cpp` - [[1]](diffhunk://#diff-2896bb4482aae85db6c9a6294ecfe7d3797e14093745a77631a93ac6c901422aR1-R145) `src/aom_video_decoder.h` - [[2]](diffhunk://#diff-e4bb77ddc2115c76ad0709ba44e1ad857c3d86ce5c4d5e2c6d9a4c8f884bebc9R1-R11)
* **OpenH264 Video Decoder**: Added `OpenH264VideoDecoder` class for decoding H.264 streams, with dynamic library loading and decoding logic. (`src/openh264_video_decoder.cpp` - [[1]](diffhunk://#diff-17b4408397811cf0f3700ce9b3e98251bffbab9948005d9746739fc6b7e5a175R1-R202) `src/openh264_video_decoder.h` - [[2]](diffhunk://#diff-ae2abe3ff8097facb4ad62b6daacd0f8305466dde0f139b1218043bd669ca8a9R1-R12)

### Codec Binding Updates:
* Integrated video decoders into the codec binding system, enabling their creation and usage via Python bindings. (`src/bind_codec.cpp` - [[1]](diffhunk://#diff-f24dddfd3b88cd7482e5ed69999c0593567dc749c6d87ed0914526a7af8a9160R16-R20) [[2]](diffhunk://#diff-f24dddfd3b88cd7482e5ed69999c0593567dc749c6d87ed0914526a7af8a9160R113-R128)

### Unit Tests for Decoders:
* Added comprehensive tests for both AOM and OpenH264 decoders, validating encoding/decoding workflows, frame integrity, and codec-specific features like NAL unit handling. (`tests/test_video_codec.py` - [tests/test_video_codec.pyR210-R503](diffhunk://#diff-15c8585be12e05a245359253abbc2afc9b59243437c16fe46f6a86d28a73b3b4R210-R503))

### Core Video Codec Enhancements:
* Introduced `VideoDecoder` interface with essential methods (`Init`, `Release`, `Decode`, `SetOnDecode`) and settings structure for codec configuration. (`src/video_codec.h` - [src/video_codec.hR122-R136](diffhunk://#diff-27087ebb437ebbdba2ddc700231a5d0001d063da0f056c0c533486bd2b5ad019R122-R136))

### Build System Updates:
* Updated `CMakeLists.txt` to include new decoder source files for compilation. (`CMakeLists.txt` - [CMakeLists.txtR64-R72](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR64-R72))