### PR TITLE
gh コマンドに切り替える

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -485,11 +485,28 @@ jobs:
           cat package_paths.env >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
         id: env
+      - name: Release (Prerelease)
+        if: contains(github.ref, 'dev')
+        run: |
+          gh release create ${{ github.ref_name }} \
+            --title "${{ github.ref_name }}" \
+            --prerelease \
+            $(cat package_paths.env)
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: ${{ steps.env.outputs.package_paths }}
-          prerelease: ${{ contains(github.ref, 'dev') }}
+        if: ${{ !contains(github.ref, 'dev') }}
+        run: |
+          gh release create ${{ github.ref_name }} \
+            --title "${{ github.ref_name }}" \
+            $(cat package_paths.env)
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Verify Release Creation
+        run: |
+          gh release view ${{ github.ref_name }} --json url
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Slack Notification
         if: failure()
         uses: rtCamp/action-slack-notify@v2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,5 +13,9 @@
 
 ### misc
 
+- [CHANGE] リリースを GH コマンドに変更
+  - `gh release create` を使用してリリースを作成するように変更する
+  - @voluntas
 - [ADD] デバッグビルドの追加
   - ローカルバージョンラベル +debug を指定している
+  - @voluntas


### PR DESCRIPTION
This pull request updates the release process in the GitHub Actions workflow to use the `gh release create` command instead of the `softprops/action-gh-release` action. Additionally, it adds a verification step for release creation and updates the `CHANGES.md` file to document these changes.

### Updates to the release process:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R488-R509): Replaced the `softprops/action-gh-release` action with the `gh release create` command for both prerelease and regular release workflows. Added conditional logic to handle prereleases (`if: contains(github.ref, 'dev')`) and regular releases (`if: ${{ !contains(github.ref, 'dev') }}`).
* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R488-R509): Introduced a new step to verify the release creation using the `gh release view` command.

### Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R16-R21): Added an entry documenting the change to the release process, specifying the use of the `gh release create` command.